### PR TITLE
Abstract surfman and implement glutin

### DIFF
--- a/rust_src/crates/webrender/Cargo.toml
+++ b/rust_src/crates/webrender/Cargo.toml
@@ -30,8 +30,10 @@ ouroboros = "0.15.5"
 errno = "0.2"
 spin_sleep = "1.1"
 winit = { package = "tao", version = "0.18", default-features = false, optional = true }
-surfman = { version = "0.4.4", features = ["sm-raw-window-handle","sm-winit"] }
 tracing = "0.1"
+surfman = { version = "0.4.4", features = ["sm-raw-window-handle","sm-winit"], optional = true }
+glutin = { version = "0.30.6", optional = true }
+euclid = "0.22.7"
 
 [dependencies.nix]
 version = "0.26"

--- a/rust_src/crates/webrender/Cargo.toml
+++ b/rust_src/crates/webrender/Cargo.toml
@@ -31,7 +31,7 @@ errno = "0.2"
 spin_sleep = "1.1"
 winit = { package = "tao", version = "0.18", default-features = false, optional = true }
 tracing = "0.1"
-surfman = { version = "0.4.4", features = ["sm-raw-window-handle","sm-winit"], optional = true }
+surfman = { version = "0.4.4", features = ["sm-raw-window-handle"], optional = true }
 glutin = { version = "0.30.6", optional = true }
 euclid = "0.22.7"
 
@@ -48,6 +48,7 @@ default-features = false
 [dependencies.webrender_surfman]
 git = "https://github.com/declantsien/webrender_surfman.git"
 rev = "e90a4e8696afe9b5301ad9cdeaf618801e0c2567"
+optional = true
 
 [build-dependencies]
 ng-bindgen = { path = "../../ng-bindgen" }
@@ -64,7 +65,7 @@ gdkwayland-sys = { version = "0.16", optional = true }
 core-foundation = "0.9.2"
 
 [features]
-default = ["std"]
+default = ["std", "winit", "surfman"]
 winit = ["dep:winit"]
 pgtk = ["dep:gtk", "dep:gtk-sys", "dep:gdk-sys", "dep:gdkwayland-sys"]
 capture=["webrender/capture", "webrender/serialize_program"]
@@ -77,3 +78,5 @@ std = [
   "fontdb/std",
   "rustybuzz/std",
 ]
+surfman = ["dep:surfman", "dep:webrender_surfman"]
+glutin = ["dep:glutin"]

--- a/rust_src/crates/webrender/src/canvas.rs
+++ b/rust_src/crates/webrender/src/canvas.rs
@@ -246,6 +246,8 @@ impl Canvas {
 
             let device_size = self.device_size();
 
+	    self.gl_context.bind_framebuffer();
+
             self.renderer.update();
 
             self.gl_context.assert_no_gl_error();
@@ -253,12 +255,12 @@ impl Canvas {
             self.renderer.render(device_size, 0).unwrap();
             let _ = self.renderer.flush_pipeline_info();
 
-            self.gl_context.swap_buffers();
-
             self.texture_resources.borrow_mut().clear();
 
             let image_key = self.copy_framebuffer_to_texture(DeviceIntRect::from_size(device_size));
             self.previous_frame_image = Some(image_key);
+
+	    self.gl_context.swap_buffers();
         }
     }
 

--- a/rust_src/crates/webrender/src/canvas.rs
+++ b/rust_src/crates/webrender/src/canvas.rs
@@ -3,18 +3,11 @@ use std::fmt;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use tracing::instrument;
 
+use crate::gl::GlContext;
 use crate::frame::LispFrameExt;
 use crate::WRFontRef;
-use euclid::default::Size2D;
 use gleam::gl;
-use log::warn;
 use std::collections::HashMap;
-
-use surfman::GLApi;
-use webrender_surfman::WebrenderSurfman;
-
-use surfman::Connection;
-use surfman::SurfaceType;
 
 use webrender::{self, api::units::*, api::*, RenderApi, Renderer, Transaction};
 
@@ -54,8 +47,7 @@ pub struct Canvas {
     // Need to droppend before window context
     renderer: Renderer,
 
-    webrender_surfman: WebrenderSurfman,
-    gl: Rc<dyn gl::Gl>,
+    gl_context: GlContext,
 
     frame: LispFrameRef,
 }
@@ -75,42 +67,10 @@ impl Canvas {
             .window_handle()
             .expect("Failed to get raw window handle from frame");
         let size = frame.size();
+        let gl_context = GlContext::new(size, display_handle, window_handle);
 
-        let connection = match Connection::from_raw_display_handle(display_handle) {
-            Ok(connection) => connection,
-            Err(error) => panic!("Device not open {:?}", error),
-        };
 
-        let adapter = connection
-            .create_adapter()
-            .expect("Failed to create adapter");
-
-        let native_widget = connection
-            .create_native_widget_from_rwh(window_handle)
-            .expect("Failed to create native widget");
-
-        let surface_type = SurfaceType::Widget { native_widget };
-
-        let webrender_surfman = WebrenderSurfman::create(&connection, &adapter, surface_type)
-            .expect("Failed to create WR surfman");
-
-        webrender_surfman
-            .resize(Size2D::new(size.width as i32, size.height as i32))
-            .unwrap();
-
-        // Get GL bindings
-        let gl = match webrender_surfman.connection().gl_api() {
-            GLApi::GL => unsafe { gl::GlFns::load_with(|s| webrender_surfman.get_proc_address(s)) },
-            GLApi::GLES => unsafe {
-                gl::GlesFns::load_with(|s| webrender_surfman.get_proc_address(s))
-            },
-        };
-
-        let gl = gl::ErrorCheckingGl::wrap(gl);
-
-        // Make sure the gl context is made current.
-        webrender_surfman.make_gl_context_current().unwrap();
-
+        // webrender
         let webrender_opts = webrender::WebRenderOptions {
             clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
             ..webrender::WebRenderOptions::default()
@@ -118,11 +78,11 @@ impl Canvas {
 
         let notifier = Box::new(Notifier::new());
         let (mut renderer, sender) =
-            webrender::create_webrender_instance(gl.clone(), notifier, webrender_opts, None)
+            webrender::create_webrender_instance(gl_context.get_gl(), notifier, webrender_opts, None)
                 .unwrap();
 
         let texture_resources = Rc::new(RefCell::new(TextureResourceManager::new(
-            gl.clone(),
+            gl_context.get_gl(),
             sender.create_api(),
         )));
 
@@ -145,12 +105,11 @@ impl Canvas {
             render_api: api,
             document_id,
             pipeline_id,
-            gl,
             epoch,
             display_list_builder: None,
             previous_frame_image: None,
             renderer,
-            webrender_surfman,
+            gl_context,
             texture_resources,
             frame,
         }
@@ -178,7 +137,8 @@ impl Canvas {
             need_flip,
         );
 
-        let gl = &self.gl;
+        // let gl = &self.gl_context.gl;
+        let gl = self.gl_context.get_gl();
         gl.bind_texture(gl::TEXTURE_2D, texture_id);
 
         gl.copy_tex_sub_image_2d(
@@ -259,19 +219,12 @@ impl Canvas {
             f(builder, space_and_clip);
         }
 
-        self.assert_no_gl_error();
+        self.gl_context.assert_no_gl_error();
     }
 
-    fn ensure_context_is_current(&mut self) {
-        // Make sure the gl context is made current.
-        if let Err(err) = self.webrender_surfman.make_gl_context_current() {
-            warn!("Failed to make GL context current: {:?}", err);
-        }
-        self.assert_no_gl_error();
-    }
 
     pub fn flush(&mut self) {
-        self.assert_no_gl_error();
+        self.gl_context.assert_no_gl_error();
 
         let builder = std::mem::replace(&mut self.display_list_builder, None);
 
@@ -293,53 +246,22 @@ impl Canvas {
 
             let device_size = self.device_size();
 
-            // Bind the webrender framebuffer
-            self.ensure_context_is_current();
-
-            let framebuffer_object = self
-                .webrender_surfman
-                .context_surface_info()
-                .unwrap_or(None)
-                .map(|info| info.framebuffer_object)
-                .unwrap_or(0);
-            self.gl
-                .bind_framebuffer(gleam::gl::FRAMEBUFFER, framebuffer_object);
-            self.assert_gl_framebuffer_complete();
-
             self.renderer.update();
 
-            self.assert_no_gl_error();
+            self.gl_context.assert_no_gl_error();
 
             self.renderer.render(device_size, 0).unwrap();
             let _ = self.renderer.flush_pipeline_info();
+
+            self.gl_context.swap_buffers();
 
             self.texture_resources.borrow_mut().clear();
 
             let image_key = self.copy_framebuffer_to_texture(DeviceIntRect::from_size(device_size));
             self.previous_frame_image = Some(image_key);
-
-            // Perform the page flip. This will likely block for a while.
-            if let Err(err) = self.webrender_surfman.present() {
-                warn!("Failed to present surface: {:?}", err);
-            }
         }
     }
 
-    #[track_caller]
-    fn assert_no_gl_error(&self) {
-        debug_assert_eq!(self.gl.get_error(), gleam::gl::NO_ERROR);
-    }
-
-    #[track_caller]
-    fn assert_gl_framebuffer_complete(&self) {
-        debug_assert_eq!(
-            (
-                self.gl.get_error(),
-                self.gl.check_frame_buffer_status(gleam::gl::FRAMEBUFFER)
-            ),
-            (gleam::gl::NO_ERROR, gleam::gl::FRAMEBUFFER_COMPLETE)
-        );
-    }
 
     pub fn get_previous_frame(&self) -> Option<ImageKey> {
         self.previous_frame_image
@@ -568,15 +490,12 @@ impl Canvas {
         txn.set_document_view(device_rect);
         self.render_api.send_transaction(self.document_id, txn);
 
-        self.webrender_surfman
-            .resize(Size2D::new(size.width as i32, size.height as i32))
-            .unwrap();
+        self.gl_context.resize(*size);
     }
 
-    pub fn deinit(self) {
-        if let Err(err) = self.webrender_surfman.make_gl_context_current() {
-            warn!("Failed to make GL context current: {:?}", err);
-        }
+
+    pub fn deinit(mut self) {
+        self.gl_context.ensure_context_is_current();
         self.renderer.deinit();
     }
 }

--- a/rust_src/crates/webrender/src/display_info.rs
+++ b/rust_src/crates/webrender/src/display_info.rs
@@ -21,8 +21,6 @@ pub struct DisplayInfoInner {
 
     pub fringe_bitmap_caches: HashMap<i32, FringeBitmap>,
 
-    pub connection: Option<surfman::Connection>,
-
     pub raw_display_handle: Option<RawDisplayHandle>,
 
     pub scale_factor: f32,
@@ -40,7 +38,6 @@ impl Default for DisplayInfoInner {
             }),
 
             fringe_bitmap_caches: HashMap::new(),
-            connection: None,
             raw_display_handle: None,
             scale_factor: 1.0,
         }

--- a/rust_src/crates/webrender/src/gl.rs
+++ b/rust_src/crates/webrender/src/gl.rs
@@ -1,0 +1,259 @@
+use log::warn;
+#[cfg(feature="glutin")]
+use glutin::{
+    surface::{Surface, WindowSurface, SurfaceAttributesBuilder},
+    context::{
+        ContextApi, ContextAttributesBuilder, Version,PossiblyCurrentContext,
+        PossiblyCurrentContextGlSurfaceAccessor,
+        NotCurrentGlContextSurfaceAccessor,
+    },
+    display::{Display, DisplayApiPreference, GlDisplay, GetGlDisplay},
+    config::{Api, ConfigTemplateBuilder, GlConfig},
+    prelude::GlSurface
+};
+
+#[cfg(feature="glutin")]
+use std::{
+    num::NonZeroU32,
+    ffi::CString,
+};
+
+#[cfg(feature="surfman")]
+use surfman::{
+    GLApi,
+    Connection,
+    SurfaceType,
+};
+
+#[cfg(feature="surfman")]
+use webrender_surfman::WebrenderSurfman;
+
+use euclid::Size2D;
+
+use raw_window_handle::{
+    RawWindowHandle,
+    RawDisplayHandle,
+};
+use webrender::api::units::DevicePixel;
+
+use std::rc::Rc;
+
+use gleam::gl::{
+    Gl, GlFns, GlesFns, ErrorCheckingGl
+};
+
+#[cfg(feature="glutin")]
+pub struct GlContext {
+    context: PossiblyCurrentContext,
+    surface: Surface<WindowSurface>,
+    gl: Rc<dyn Gl>
+}
+
+#[cfg(feature="glutin")]
+impl GlContext {
+    pub fn new(size: Size2D<i32, DevicePixel>, display_handle: RawDisplayHandle, window_handle: RawWindowHandle) -> Self {
+        let width = NonZeroU32::new(size.width as u32).unwrap();
+        let height = NonZeroU32::new(size.height as u32).unwrap();
+
+
+        // glutin
+        let preference = DisplayApiPreference::Egl;
+        let gl_display = unsafe {Display::new(display_handle, preference) }.unwrap();
+        let template = ConfigTemplateBuilder::new().build(); // TODO do we need to do anything to this?
+        let gl_config = unsafe {
+            let configs = gl_display.find_configs(template).unwrap();
+            // get best config
+            configs
+                .reduce(|accum, config| {
+                    if config.num_samples() > accum.num_samples() {
+                        config
+                    } else {
+                        accum
+                    }
+                })
+                .unwrap()
+        };
+
+        let context_attributes = ContextAttributesBuilder::new().build(Some(window_handle));
+        // Since glutin by default tries to create OpenGL core context, which may not be
+        // present we should try gles.
+        let fallback_context_attributes = ContextAttributesBuilder::new()
+            .with_context_api(ContextApi::Gles(None))
+            .build(Some(window_handle));
+
+        // There are also some old devices that support neither modern OpenGL nor GLES.
+        // To support these we can try and create a 2.1 context.
+        let legacy_context_attributes = ContextAttributesBuilder::new()
+            .with_context_api(ContextApi::OpenGl(Some(Version::new(2, 1))))
+            .build(Some(window_handle));
+
+        let mut context = Some(unsafe {
+            gl_display.create_context(&gl_config, &context_attributes).unwrap_or_else(|_| {
+                gl_display.create_context(&gl_config, &fallback_context_attributes).unwrap_or_else(
+                    |_| {
+                        gl_display
+                            .create_context(&gl_config, &legacy_context_attributes)
+                            .expect("failed to create context")
+                    },
+                )
+            })
+        });
+
+        let attrs = SurfaceAttributesBuilder::<WindowSurface>::new().build(
+            window_handle, width, height
+        );
+        let surface = unsafe { gl_display.create_window_surface(&gl_config, &attrs).unwrap()};
+        let context = context.take().unwrap().make_current(&surface).unwrap();
+        // TODO haven't we done this above?
+        surface.resize(&context, width, height);
+
+        let gl = {
+            let flags = gl_config.api();
+            if flags.contains(Api::OPENGL) {
+                unsafe {GlFns::load_with(|symbol| gl_config.display().get_proc_address(&CString::new(symbol).unwrap()) as *const _)}
+            } else if flags.intersects(Api::GLES1 | Api::GLES2 | Api::GLES3 ) {
+                unsafe {GlesFns::load_with(|symbol| gl_config.display().get_proc_address(&CString::new(symbol).unwrap()) as *const _)}
+            } else {
+                unimplemented!();
+            }
+        };
+
+        GlContext {
+            surface,
+            context,
+            gl,
+        }
+    }
+
+    pub fn swap_buffers(&self) {
+        self.surface.swap_buffers(&self.context).ok();
+    }
+
+    pub fn resize(&self, size: Size2D<i32, DevicePixel>) {
+        self.surface
+            .resize(
+                &self.context,
+                NonZeroU32::new(size.width as u32).unwrap(),
+                NonZeroU32::new(size.height as u32).unwrap());
+    }
+
+    pub fn ensure_context_is_current(&mut self) {
+        // Make sure the gl context is made current.
+        if let Err(err) = self.context.make_current(&self.surface) {
+            warn!("Failed to make GL context current: {:?}", err);
+        }
+        self.assert_no_gl_error();
+    }
+
+    #[track_caller]
+    pub fn assert_no_gl_error(&self) {
+        debug_assert_eq!(self.gl.get_error(), gleam::gl::NO_ERROR);
+    }
+
+    #[track_caller]
+    pub fn assert_gl_framebuffer_complete(&self) {
+        debug_assert_eq!(
+            (
+                self.gl.get_error(),
+                self.gl.check_frame_buffer_status(gleam::gl::FRAMEBUFFER)
+            ),
+            (gleam::gl::NO_ERROR, gleam::gl::FRAMEBUFFER_COMPLETE)
+        );
+    }
+
+    pub fn get_gl(&self) -> Rc<dyn Gl> {
+        ErrorCheckingGl::wrap(self.gl.clone())
+    }
+}
+#[cfg(feature="surfman")]
+pub struct GlContext {
+    webrender_surfman: WebrenderSurfman,
+    gl: Rc<dyn Gl>
+}
+
+#[cfg(feature="surfman")]
+impl GlContext {
+    pub fn new(size: Size2D<i32, DevicePixel>, display_handle: RawDisplayHandle, window_handle: RawWindowHandle) -> Self {
+        let connection = match Connection::from_raw_display_handle(display_handle) {
+            Ok(connection) => connection,
+            Err(error) => panic!("Device not open {:?}", error),
+        };
+
+        let adapter = connection
+            .create_adapter()
+            .expect("Failed to create adapter");
+
+        let native_widget = connection
+            .create_native_widget_from_rwh(window_handle)
+            .expect("Failed to create native widget");
+
+        let surface_type = SurfaceType::Widget { native_widget };
+
+        let webrender_surfman = WebrenderSurfman::create(&connection, &adapter, surface_type)
+            .expect("Failed to create WR surfman");
+
+        webrender_surfman
+            .resize(Size2D::new(size.width as i32, size.height as i32))
+            .unwrap();
+
+        // Get GL bindings
+        let gl = match webrender_surfman.connection().gl_api() {
+            GLApi::GL => unsafe { GlFns::load_with(|s| webrender_surfman.get_proc_address(s)) },
+            GLApi::GLES => unsafe {
+                GlesFns::load_with(|s| webrender_surfman.get_proc_address(s))
+            },
+        };
+        webrender_surfman.make_gl_context_current().unwrap();
+
+        GlContext {
+            webrender_surfman,
+            gl,
+        }
+    }
+
+    pub fn swap_buffers(&self) {
+        let framebuffer_object = self
+            .webrender_surfman
+            .context_surface_info()
+            .unwrap_or(None)
+            .map(|info| info.framebuffer_object)
+            .unwrap_or(0);
+        self.gl
+            .bind_framebuffer(gleam::gl::FRAMEBUFFER, framebuffer_object);
+        self.assert_gl_framebuffer_complete();
+
+        if let Err(err) = self.webrender_surfman.present() {
+            warn!("Failed to present surface: {:?}", err);
+        }
+    }
+
+    #[track_caller]
+    pub fn assert_gl_framebuffer_complete(&self) {
+        debug_assert_eq!(
+            (
+                self.gl.get_error(),
+                self.gl.check_frame_buffer_status(gleam::gl::FRAMEBUFFER)
+            ),
+            (gleam::gl::NO_ERROR, gleam::gl::FRAMEBUFFER_COMPLETE)
+        );
+    }
+
+    pub fn resize(&self, size: Size2D<i32, DevicePixel>) {
+        self.webrender_surfman
+            .resize(Size2D::new(size.width as i32, size.height as i32))
+            .unwrap();
+    }
+
+    pub fn ensure_context_is_current(&mut self) {
+        self.webrender_surfman.make_gl_context_current();
+    }
+
+    #[track_caller]
+    pub fn assert_no_gl_error(&self) {
+        debug_assert_eq!(self.gl.get_error(), gleam::gl::NO_ERROR);
+    }
+    // TODO move duplicate stuff to trait
+    pub fn get_gl(&self) -> Rc<dyn Gl> {
+        ErrorCheckingGl::wrap(self.gl.clone())
+    }
+}

--- a/rust_src/crates/webrender/src/gl.rs
+++ b/rust_src/crates/webrender/src/gl.rs
@@ -125,6 +125,8 @@ impl GlContext {
         }
     }
 
+    pub fn bind_framebuffer(&self) {}
+
     pub fn swap_buffers(&self) {
         self.surface.swap_buffers(&self.context).ok();
     }
@@ -211,7 +213,10 @@ impl GlContext {
         }
     }
 
-    pub fn swap_buffers(&self) {
+    pub fn bind_framebuffer(&mut self) {
+	// Bind the webrender framebuffer
+        self.ensure_context_is_current();
+
         let framebuffer_object = self
             .webrender_surfman
             .context_surface_info()
@@ -221,7 +226,10 @@ impl GlContext {
         self.gl
             .bind_framebuffer(gleam::gl::FRAMEBUFFER, framebuffer_object);
         self.assert_gl_framebuffer_complete();
+    }
 
+    pub fn swap_buffers(&self) {
+	// Perform the page flip. This will likely block for a while.
         if let Err(err) = self.webrender_surfman.present() {
             warn!("Failed to present surface: {:?}", err);
         }

--- a/rust_src/crates/webrender/src/lib.rs
+++ b/rust_src/crates/webrender/src/lib.rs
@@ -26,6 +26,7 @@ mod renderer;
 mod texture;
 pub mod util;
 mod wrterm;
+mod gl;
 
 pub use crate::font::*;
 pub use crate::term::*;

--- a/rust_src/crates/winit-term/Cargo.toml
+++ b/rust_src/crates/winit-term/Cargo.toml
@@ -28,7 +28,6 @@ raw-window-handle = "0.5"
 fontdb = "0.11"
 errno = "0.2"
 spin_sleep = "1.1"
-surfman = { version = "0.4.4", features = ["sm-raw-window-handle","sm-winit"] }
 
 [dependencies.nix]
 version = "0.26"
@@ -39,10 +38,6 @@ features = ["signal"]
 git = "https://github.com/servo/webrender.git"
 rev = "91fdbacc15263e738efeb3ff9d4bf8befbeae88e"
 default-features = false
-
-[dependencies.webrender_surfman]
-git = "https://github.com/declantsien/webrender_surfman.git"
-rev = "e90a4e8696afe9b5301ad9cdeaf618801e0c2567"
 
 [build-dependencies]
 ng-bindgen = { path = "../../ng-bindgen" }
@@ -61,7 +56,6 @@ optional = true
 core-foundation = "0.9.2"
 
 [features]
-default = ["winit"]
-winit = ["wr-renderer"]
-capture=["webrender/capture", "webrender/serialize_program"]
-sw_compositor=["webrender/sw_compositor"]
+default = ["x11", "wayland", "wr-renderer/winit"]
+x11 = ["dep:x11"]
+wayland = []


### PR DESCRIPTION
Unfortunately I need to rebase this against tao: used feature/tao by mistake.

This PR:
- abstracts the surfman/glutin gl context creation into a new module `gl`
- implements glutin context creation

Glutin runs on my machine, although there is still work to do.  Surfman still crashes, but compiles.

I'll rebase this against tao shortly.

I'm learning rust and feel the use of `cfg` all over the place here is ugly.  I'd appreciate advice on how to tidy it up.