### PR TITLE
Fix mouse position and some numpad chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,4 @@ lib-src/seccomp-filter-exec.pfc
 _gdb_history
 /.cargo/config.toml
 /.cargo/config
+/aur/

--- a/rust_src/crates/webrender/src/canvas.rs
+++ b/rust_src/crates/webrender/src/canvas.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use tracing::instrument;
 
-use crate::gl::GlContext;
 use crate::frame::LispFrameExt;
+use crate::gl::GlContext;
 use crate::WRFontRef;
 use gleam::gl;
 use std::collections::HashMap;
@@ -69,7 +69,6 @@ impl Canvas {
         let size = frame.size();
         let gl_context = GlContext::new(size, display_handle, window_handle);
 
-
         // webrender
         let webrender_opts = webrender::WebRenderOptions {
             clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
@@ -77,9 +76,13 @@ impl Canvas {
         };
 
         let notifier = Box::new(Notifier::new());
-        let (mut renderer, sender) =
-            webrender::create_webrender_instance(gl_context.get_gl(), notifier, webrender_opts, None)
-                .unwrap();
+        let (mut renderer, sender) = webrender::create_webrender_instance(
+            gl_context.get_gl(),
+            notifier,
+            webrender_opts,
+            None,
+        )
+        .unwrap();
 
         let texture_resources = Rc::new(RefCell::new(TextureResourceManager::new(
             gl_context.get_gl(),
@@ -222,7 +225,6 @@ impl Canvas {
         self.gl_context.assert_no_gl_error();
     }
 
-
     pub fn flush(&mut self) {
         self.gl_context.assert_no_gl_error();
         self.gl_context.ensure_context_is_current();
@@ -247,7 +249,7 @@ impl Canvas {
 
             let device_size = self.device_size();
 
-	    self.gl_context.bind_framebuffer();
+            self.gl_context.bind_framebuffer();
 
             self.renderer.update();
 
@@ -261,10 +263,9 @@ impl Canvas {
             let image_key = self.copy_framebuffer_to_texture(DeviceIntRect::from_size(device_size));
             self.previous_frame_image = Some(image_key);
 
-	    self.gl_context.swap_buffers();
+            self.gl_context.swap_buffers();
         }
     }
-
 
     pub fn get_previous_frame(&self) -> Option<ImageKey> {
         self.previous_frame_image
@@ -495,7 +496,6 @@ impl Canvas {
 
         self.gl_context.resize(*size);
     }
-
 
     pub fn deinit(mut self) {
         self.gl_context.ensure_context_is_current();

--- a/rust_src/crates/webrender/src/frame.rs
+++ b/rust_src/crates/webrender/src/frame.rs
@@ -77,9 +77,9 @@ impl LispFrameExt for LispFrameRef {
 
         #[cfg(window_system = "pgtk")]
         {
+            use gtk::prelude::WidgetExt;
             use raw_window_handle::WaylandWindowHandle;
             use std::ptr;
-            use gtk::prelude::WidgetExt;
             let mut output = self.output();
             // let wtop = output.as_raw().widget;
             // let wvbox = output.as_raw().vbox_widget;
@@ -89,12 +89,15 @@ impl LispFrameExt for LispFrameRef {
                 gtk_sys::gtk_widget_set_opacity(widget, 0.0);
             }
 
-            let transparent = gdk_sys::GdkRGBA{
+            let transparent = gdk_sys::GdkRGBA {
                 red: 0.0,
                 green: 0.0,
                 blue: 0.0,
-                alpha: 0.0};
-            unsafe { gtk_sys::gtk_widget_override_background_color (widget, 0, &transparent); }
+                alpha: 0.0,
+            };
+            unsafe {
+                gtk_sys::gtk_widget_override_background_color(widget, 0, &transparent);
+            }
             // if wfixed != ptr::null_mut() {
             //     unsafe { gtk_sys::gtk_widget_destroy(wfixed) }
             // }

--- a/rust_src/crates/webrender/src/fringe.rs
+++ b/rust_src/crates/webrender/src/fringe.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use crate::frame::LispFrameExt;
 use crate::output::OutputRef;
 use bit_vec::BitVec;
-use image::{DynamicImage, GenericImageView, Rgba, RgbaImage};
 use emacs::frame::LispFrameRef;
-use crate::frame::LispFrameExt;
+use image::{DynamicImage, GenericImageView, Rgba, RgbaImage};
 
 use emacs::bindings::draw_fringe_bitmap_params;
 use webrender::api::ImageKey;

--- a/rust_src/crates/webrender/src/lib.rs
+++ b/rust_src/crates/webrender/src/lib.rs
@@ -22,11 +22,11 @@ pub mod term;
 mod cursor;
 mod font_db;
 mod fringe;
+mod gl;
 mod renderer;
 mod texture;
 pub mod util;
 mod wrterm;
-mod gl;
 
 pub use crate::font::*;
 pub use crate::term::*;

--- a/rust_src/crates/winit-term/src/frame.rs
+++ b/rust_src/crates/winit-term/src/frame.rs
@@ -18,7 +18,10 @@ use winit::window::WindowId;
 use wr_renderer::frame::LispFrameExt;
 use wr_renderer::output::Output;
 
-use winit::{dpi::PhysicalPosition, window::WindowBuilder};
+use winit::{
+    dpi::{LogicalPosition, PhysicalPosition},
+    window::WindowBuilder,
+};
 
 use wr_renderer::display_info::DisplayInfoRef;
 
@@ -86,7 +89,7 @@ pub trait LispFrameWinitExt {
     fn implicitly_set_name(&mut self, arg: LispObject, _old_val: LispObject);
     fn iconify(&mut self);
     fn current_monitor(&self) -> Option<MonitorHandle>;
-    fn cursor_position(&self) -> PhysicalPosition<i32>;
+    fn cursor_position(&self) -> LogicalPosition<i32>;
 }
 
 impl LispFrameWinitExt for LispFrameRef {
@@ -226,16 +229,16 @@ impl LispFrameWinitExt for LispFrameRef {
         window.current_monitor()
     }
 
-    fn cursor_position(&self) -> PhysicalPosition<i32> {
+    fn cursor_position(&self) -> LogicalPosition<i32> {
         let inner = self.output().get_inner();
         let window = inner
             .window
             .as_ref()
             .expect("frame doesnt have associated winit window yet");
         if let Ok(pos) = window.cursor_position() {
-            return pos.cast();
+            return LogicalPosition::<i32>::from_physical(pos, 1.0 / window.scale_factor());
         }
 
-        PhysicalPosition::new(0, 0)
+        LogicalPosition::new(0, 0)
     }
 }

--- a/rust_src/crates/winit-term/src/input.rs
+++ b/rust_src/crates/winit-term/src/input.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 use winit::{
-    dpi::PhysicalPosition,
+    dpi::{LogicalPosition, PhysicalPosition},
     event::{ElementState, MouseButton, MouseScrollDelta, TouchPhase},
     keyboard::{KeyCode as VirtualKeyCode, ModifiersState},
 };
@@ -160,7 +160,7 @@ impl InputProcessor {
             _ => todo!(),
         };
 
-        let mut pos = PhysicalPosition::new(0, 0);
+        let mut pos = LogicalPosition::new(0, 0);
 
         if let Some(frame) = top_frame.as_frame() {
             pos = frame.cursor_position();
@@ -244,7 +244,7 @@ impl InputProcessor {
 
         let (kind, is_upper, lines) = event_meta.unwrap();
 
-        let mut pos = PhysicalPosition::new(0, 0);
+        let mut pos = LogicalPosition::new(0, 0);
 
         if let Some(frame) = top_frame.as_frame() {
             pos = frame.cursor_position();
@@ -316,8 +316,7 @@ pub fn winit_keycode_emacs_key_name(keycode: VirtualKeyCode) -> *const libc::c_c
         VirtualKeyCode::Escape => kn!("escape"),
         VirtualKeyCode::Backspace => kn!("backspace"),
         VirtualKeyCode::Delete => kn!("deletechar"),
-        VirtualKeyCode::Enter
-            |VirtualKeyCode::NumpadEnter=> kn!("return"),
+        VirtualKeyCode::Enter | VirtualKeyCode::NumpadEnter => kn!("return"),
         VirtualKeyCode::Tab => kn!("tab"),
 
         VirtualKeyCode::Home => kn!("home"),

--- a/rust_src/crates/winit-term/src/input.rs
+++ b/rust_src/crates/winit-term/src/input.rs
@@ -315,7 +315,9 @@ pub fn winit_keycode_emacs_key_name(keycode: VirtualKeyCode) -> *const libc::c_c
     match keycode {
         VirtualKeyCode::Escape => kn!("escape"),
         VirtualKeyCode::Backspace => kn!("backspace"),
-        VirtualKeyCode::Enter => kn!("return"),
+        VirtualKeyCode::Delete => kn!("deletechar"),
+        VirtualKeyCode::Enter
+            |VirtualKeyCode::NumpadEnter=> kn!("return"),
         VirtualKeyCode::Tab => kn!("tab"),
 
         VirtualKeyCode::Home => kn!("home"),

--- a/rust_src/crates/winit-term/src/term.rs
+++ b/rust_src/crates/winit-term/src/term.rs
@@ -213,6 +213,7 @@ extern "C" fn winit_read_input_event(terminal: *mut terminal, hold_quit: *mut in
 
     for e in events.iter() {
         let e = e.clone();
+        log::trace!("Handling event {:?}", e);
 
         match e {
             Event::RedrawRequested(window_id) => {
@@ -275,7 +276,7 @@ extern "C" fn winit_read_input_event(terminal: *mut terminal, hold_quit: *mut in
                         ElementState::Released => {
                             InputProcessor::handle_key_released();
                         }
-                        _ => todo!(),
+                        e => todo!("Unhandled event {:?}", e),
                     },
 
                     WindowEvent::MouseInput { state, button, .. } => {


### PR DESCRIPTION
Since this requires the *reciprocal* of the window scale it's clearly a hack---something is thinking in the wrong units.  However with this I am able to click in the right place again.

Also add some missing keys, although a better solution for the numpad would be to use logical_key `Key`s and do the mapping ourselves.  But I'm not sure how many emacs users actually use the numpad arrows, and ofc they don't even exist on mac keyboards.